### PR TITLE
Render tasks with runner

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <script src="js/time_machine.js" defer></script>
 
     <script src="lib/EventEmitter.js" defer></script>
+    <script src="js/friendly_runner.js" defer></script>
     <script src="js/color_manager.js" defer></script>
     <script src="js/thread.js" defer></script>
     <script src="js/source_event_type.js" defer></script>

--- a/js/friendly_runner.js
+++ b/js/friendly_runner.js
@@ -1,0 +1,48 @@
+/* -*- Mode: Javascript; tab-width: 2; indent-tabs-mode: nil; js-indent-level: 2 -*- */
+'use strict';
+
+(function(exports) {
+  function FriendlyRunner() {
+    this.init();
+  }
+
+  FriendlyRunner.prototype = {
+    schedule_runners: function () {
+      var self = this;
+
+      if (this.runners.length == 0 || this.is_running) {
+        return;
+      }
+
+      this.is_running = true;
+
+      function _run_runner() {
+        if (self.runners.length == 0) {
+          self.is_running = false;
+          return;
+        }
+        window.setTimeout(function() {
+          var runner = self.runners[0];
+          self.runners.splice(0, 1);
+          runner();
+          _run_runner();
+        });
+      }
+      _run_runner();
+    },
+
+    dispatch_runner: function(runner) {
+      this.runners.push(runner);
+      this.schedule_runners();
+    },
+
+    init: function() {
+      this.runners = [];
+      this.is_running = false;
+      window.broadcaster.on('-friendly-runner',
+                            this.dispatch_runner.bind(this));
+    }
+  };
+
+  exports.FriendlyRunner = FriendlyRunner;
+})(this);

--- a/js/main.js
+++ b/js/main.js
@@ -2,5 +2,6 @@
 
 (function(exports) {
   self.broadcaster = new EventEmitter();
+  self.friendly_runner = new FriendlyRunner();
   self.app = new self.App();
 }(this));

--- a/js/thread.js
+++ b/js/thread.js
@@ -327,35 +327,6 @@
     window.broadcaster.emit('-thread-destroyed');
   };
 
-  var render_tasks = [];
-  var render_running = false;
-
-  function schedule_runners() {
-    if (render_tasks.length == 0 || render_running) {
-      return;
-    }
-
-    render_running = true;
-
-    function _run_runner() {
-      if (render_tasks.length == 0) {
-        render_running = false;
-        return;
-      }
-      window.setTimeout(function() {
-        var runner = render_tasks[0];
-        render_tasks.splice(0, 1);
-        runner();
-        _run_runner();
-      });
-    }
-    _run_runner();
-  }
-  function dispatch_runner(runner) {
-    render_tasks.push(runner);
-    schedule_runners();
-  }
-
   Thread.prototype.render = function() {
     if (this._rendered || !this.config.tasks) {
       return;
@@ -391,7 +362,8 @@
     var run_size = 200;
     for (var i = 0; i < this.config.tasks.length; i += run_size) {
       var render_content = this.config.tasks.slice(i, i + run_size);
-      dispatch_runner(create_runner(render_content));
+      window.broadcaster.emit('-friendly-runner',
+                              create_runner(render_content));
     }
 
     this.element.mousemove(function(evt) {


### PR DESCRIPTION
Use an GUI friendly task runner to avoid blocking GUI.  Runners are submitted to the browser one at once to avoid occupied task queue for a long time.
