### PR TITLE
Provide a quick JS command to jump to a given task.

### DIFF
--- a/js/task_manager.js
+++ b/js/task_manager.js
@@ -24,5 +24,12 @@
     return this._tasks[id];
   };
 
+  TaskManager.prototype.focusTask = function(id) {
+    var task = this._tasks[id];
+    window.broadcaster.emit('focus-task', task.view.execution);
+    window.broadcaster.emit('thread-focused', task.threadId);
+    window.broadcaster.emit('-task-hovered', task);
+  };
+
   exports.TaskManager = TaskManager;
 }(this));


### PR DESCRIPTION
It provide a way to jump to specified task given by the number of task ID.  By running window.app.taskManager.focusTask(<task ID>) at JS console, the user could jump to a task quickly with a known task ID.  It would be useful for demo and discussion on issue tracker.
